### PR TITLE
Add connection status indicator

### DIFF
--- a/TestBlazor/Components/Pages/Movies.razor
+++ b/TestBlazor/Components/Pages/Movies.razor
@@ -6,6 +6,10 @@
 @inject NavigationManager Navigation
 @implements IAsyncDisposable
 
+<div class="alert alert-info mb-3">
+    Connection: @connectionStatus
+</div>
+
 <h3>Movies</h3>
 
 @if (moviesList == null)
@@ -143,6 +147,7 @@ else
     private int movieToDeleteId;
     private string movieToDeleteTitle;
     private HubConnection? hubConnection;
+    private string connectionStatus = "Connecting";
 
     protected override async Task OnInitializedAsync()
     {
@@ -153,6 +158,24 @@ else
             .WithAutomaticReconnect()
             .Build();
 
+        hubConnection.Reconnecting += error =>
+        {
+            connectionStatus = "Reconnecting";
+            return InvokeAsync(StateHasChanged);
+        };
+
+        hubConnection.Reconnected += connectionId =>
+        {
+            connectionStatus = "Connected";
+            return InvokeAsync(StateHasChanged);
+        };
+
+        hubConnection.Closed += error =>
+        {
+            connectionStatus = "Disconnected";
+            return InvokeAsync(StateHasChanged);
+        };
+
         hubConnection.On("ReceiveMovieUpdate", async () =>
         {
             await LoadMovies();
@@ -160,6 +183,7 @@ else
         });
 
         await hubConnection.StartAsync();
+        connectionStatus = "Connected";
     }
 
     private async Task LoadMovies()


### PR DESCRIPTION
## Summary
- show connection status in `Movies.razor`
- track SignalR connection lifecycle to update the status

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862cc5fb404832d8aacdc813e73f4df